### PR TITLE
Fix issue #22; Add ext_tables.php with StaticFile template for TYPO3 < 8.7.x

### DIFF
--- a/ext_tables.php
+++ b/ext_tables.php
@@ -1,0 +1,14 @@
+<?php
+
+if (!defined('TYPO3_MODE')) {
+    die('Access denied.');
+}
+
+/**
+ * Include TypoScript
+ */
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
+    $_EXTKEY,
+    'Configuration/TypoScript',
+    'reCAPTCHA'
+);


### PR DESCRIPTION
On TYPO3 7.6.x static template via TCA/sys_template.php does not seem to work.